### PR TITLE
Add table headers to events page

### DIFF
--- a/templates/app/events.html
+++ b/templates/app/events.html
@@ -27,6 +27,17 @@
 </header>
 	
 <div id="main">
+    <div class="row">
+        <div class="span4">
+            <strong>Event</strong>
+        </div>
+        <div class="span2">
+            <strong>Event Date</strong>
+        </div>
+        <div class="offset2 span1">
+            <strong>Status</strong>
+        </div>
+    </div>
   {% for app in apps %}
   <div class="app-item-row">
     <div class="row">


### PR DESCRIPTION
Of specific importance is the date column, which refers to event date,
not, submission date.

Close issue #60
