### PR TITLE
Set up config for registration email

### DIFF
--- a/import_demo.py
+++ b/import_demo.py
@@ -9,7 +9,7 @@ from django.contrib.sites.models import Site
 
 from app.models import *
 
-from sandbox_config import URL_ROOT, TEST_EMAIL
+from sandbox_config import SITE_NAME, URL_ROOT, TEST_EMAIL
 
 
 QUESTIONS = [
@@ -213,7 +213,7 @@ def import_questions():
 
 def import_sites():
   site = Site.objects.get_current()
-  site.domain = "www.pennapps.com%s/" % URL_ROOT
+  site.domain = SITE_NAME + URL_ROOT
   site.name = "The Common Funding App"
   site.save()
 

--- a/sandbox_config.py_default
+++ b/sandbox_config.py_default
@@ -9,6 +9,8 @@ This and nothing else.  (In the ominous words of AMK.)
 
 import os
 
+# Name of the site you are developing on. This is only needed for registration links to work.
+SITE_NAME = "www.pennapps.com"
 # i.e., pennapps.com/<DISPLAY_NAME>, this should be the empty string in prod
 DISPLAY_NAME = ""
 URL_ROOT = "/" + DISPLAY_NAME

--- a/settings.py
+++ b/settings.py
@@ -9,7 +9,11 @@ TEMPLATE_DEBUG = DEBUG
 
 PROJECT_ROOT = os.path.realpath(os.path.dirname(__file__))
 
+# Number of days a user has to activate his account after registration
 ACCOUNT_ACTIVATION_DAYS = 7
+
+# Email address to use for automated registration emails
+DEFAULT_FROM_EMAIL = "no-reply@pennapps.com"
 
 LOGIN_URL = URL_ROOT + "/accounts/login/"
 LOGOUT_URL = URL_ROOT + "/accounts/logout/"


### PR DESCRIPTION
In order for the registration email to be valid, we each will need to
define SITE_NAME to be our actual site name.

This is because django-registration pull the site name from the Site object.

See line 242 on the django-registration [docs](https://bitbucket.org/ubernostrum/django-registration/src/27bccd108cde/registration/models.py) for details.

Fixes Issue #99
