### PR TITLE
Add email creds

### DIFF
--- a/sandbox_config.py_default
+++ b/sandbox_config.py_default
@@ -25,3 +25,9 @@ DATABASE_HOST = ''           # Leave as empty string for localhost
 DATABASE_NAME = 'cfa'        # Or relative path to database file if using sqlite3
 DATABASE_USER = ''           # Not used with sqlite3
 DATABASE_PASSWORD = ''       # Not used with sqlite3
+
+# Email client info, for registration and notification emails
+EMAIL_HOST = 'smtp.sendgrid.net'
+EMAIL_PORT = 587
+EMAIL_HOST_USER = ''
+EMAIL_HOST_PASSWORD = ''


### PR DESCRIPTION
@scwu @adelq 

This should fix #193. I've already updated the prod droplet with Sendgrid params (which Django will use accordingly). But I don't know if it will work yet as Sendgrid is still provisioning and can't send e-mail. I added the sendgrid creds to the passwords doc — you should get an e-mail at pennappslabs@gmail.com when they're done, at which point you should test creating new users and makes sure it send the registration e-mail properly
