### PR TITLE
limited editing available for requesters on funded events

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -207,10 +207,15 @@ class Event(models.Model):
         categories = POST.getlist('item_category')
         revenues = POST.getlist('item_revenue')
 
-        self.item_set.all().delete()
+        for item in self.item_set.all():
+            if not Grant.objects.filter(item = item):
+                item.delete()
+
         zipped_items = zip(names, quantities, prices_per_unit,
                            funding_already_received, categories, revenues)
         for name, quantity, price, funding, cat, rev in zipped_items:
+            if Item.objects.filter(event = self, name = name):
+                continue
             funding = funding or 0
             # set correct category letter
             for tup in CATEGORIES:

--- a/app/static/coffeescripts/form.coffee
+++ b/app/static/coffeescripts/form.coffee
@@ -105,6 +105,7 @@ $ ->
   disableIneligibleFunders()
 
   $('.ineligible').live 'click', disableCheckbox
+  $('.disable').live 'click', disableCheckbox
 
   $(".funder-checkbox").change ->
     funder_id = $(this).data("funderid")
@@ -116,6 +117,8 @@ $ ->
     showQuestions()
 
   $(".bool-q").change ->
+    if $(this).hasClass("disable")
+      return
     updateEligibileFunders()
     disableIneligibleFunders()
     showQuestions()

--- a/app/templatetags/widgets.py
+++ b/app/templatetags/widgets.py
@@ -94,7 +94,7 @@ def application(context, user, event):
 
   try:
     is_funder = user.get_profile().is_funder
-    if not user or not user.is_authenticated() or user.is_staff or is_funder or event.locked:
+    if not user or not user.is_authenticated() or user.is_staff or is_funder or event.over:
       new_context['extra_attrs'] = 'readonly'
       new_context['readonly'] = True
   except:

--- a/app/views.py
+++ b/app/views.py
@@ -152,11 +152,14 @@ def event_new(request):
 @requester_only
 def event_edit(request, event_id):
     event = Event.objects.get(pk=event_id)
-    if event.locked:
+    if event.over:
         return redirect('app.views.event_show', event_id)
     if request.method == 'POST':
         if event.followup_needed:
             status = 'O'  # O for OVER
+        elif event.funded:
+            # keep status as funded when partially funded event is edited.
+            status = 'F'  # F for FUNDED
         elif "submit-event" in request.POST:
             status = 'B'  # B for SUBMITTED
         else:

--- a/templates/app/events.html
+++ b/templates/app/events.html
@@ -81,7 +81,7 @@
         {% endif %}
       </div>
       <div class="span2 buttons">
-        {% if user.is_staff or app.locked or user.get_profile.is_funder %}
+        {% if user.is_staff or event.over or user.get_profile.is_funder %}
         <a class="btn btn-info" href="{% url app.views.event_show app.id %}">
           <i class="icon-file icon-white"></i> View
         </a>

--- a/templates/app/templatetags/application.html
+++ b/templates/app/templatetags/application.html
@@ -47,7 +47,7 @@
   <div class="section-content">
     <fieldset>
       {% for qa in eligibility_qas %}
-        {% if not readonly or qa.answer.answer %}
+        {% if not readonly and not event.funded or qa.answer.answer %}
         <div class="control-group">
           <label id="eligibilitylabel_{{qa.question.id}}"
                  class="control-label">
@@ -58,7 +58,11 @@
                      id="eligibilityquestion_{{qa.question.id}}"
                      name="eligibilityquestion_{{qa.question.id}}"
                      data-required-funder-ids="{{qa.question.required_funder_ids}}"
+                     {% if event.funded %}
+                     class="bool-q disable" readonly
+                     {% else %}
                      class="bool-q"
+                     {% endif %}
                      data-qid="{{qa.question.id}}"
                      {{extra_attrs}} {{event_over_disable}}
                      {% if qa.answer.answer %}checked{% endif %}>
@@ -84,7 +88,8 @@
         id="commonfreeresponsequestion_{{qa.question.id}}"
         name="commonfreeresponsequestion_{{qa.question.id}}"
         class="span8 commonfreeresponsequestion input-xlarge"
-        {{extra_attrs}} {{event_over_disable}}>{{qa.answer.answer}}</textarea>
+        {{extra_attrs}} {{event_over_disable}}
+        {% if event.funded %}readonly{% endif %}>{{qa.answer.answer}}</textarea>
       {% endfor %}
     </fieldset>
   </div>

--- a/templates/app/templatetags/itemlist-requester.html
+++ b/templates/app/templatetags/itemlist-requester.html
@@ -37,11 +37,11 @@
           <input name="item_revenue" type="hidden" value="{{ is_revenue }}" />
           <td>
             <input name="item_name" type="text" class='small'
-              required {% if funded %} disabled {% endif %}
+              required {% if funded %} readonly {% endif %}
               value="{{ item.name }}" />
           </td>
           <td>
-            <select class="item-category" name='item_category' {% if funded %} disabled {% endif %}>
+            <select class="item-category" name='item_category' {% if funded %} readonly {% endif %}>
               <option> {{ item.get_category_display }} </option>
               {% for item_category in CATEGORIES %}
                 {% if item_category.1 != item.get_category_display %}
@@ -52,7 +52,7 @@
           </td>
           <td>
             <input name="item_quantity" type="number" class='small'
-              required {% if funded %} disabled {% endif %}
+              required {% if funded %} readonly {% endif %}
               pattern="^\d+"
               value="{{ item.quantity }}" />
           </td>
@@ -60,7 +60,7 @@
             <div class="input-prepend">
               <span class="add-on">$</span>
               <input class="inputIcon small input-with-dollar" name="item_price_per_unit"
-                required {% if funded %} disabled {% endif %} type="number"
+                required {% if funded %} readonly {% endif %} type="number"
                 pattern="^\d*(\.\d{2}$)?" step="0.01"
                 value="{{ item.price_per_unit }}"/>
             </div>
@@ -69,7 +69,7 @@
             <div class="input-prepend">
               <span class="add-on">$</span>
               <input class="inputIcon small input-with-dollar" name="item_funding_already_received"
-                type="number" required {% if funded %} disabled {% endif %}
+                type="number" required {% if funded %} readonly {% endif %}
                 pattern="^\d*(\.\d{2}$)?" step="0.01"
                 value="{{ item.funding_already_received }}" />
             </div>
@@ -85,7 +85,6 @@
           {% endif %}
         </tr>
     {% endfor %}
-    {% if not funded %}
     <tr class='itemrow {% if is_revenue %} revenue-item {% else %} expense-item {% endif %}'>
       <input name="item_revenue" type="hidden" value="{{ is_revenue }}" />
       <td>
@@ -121,8 +120,6 @@
         <button class='btn add add-item'>Add</button>
       </td>
     </tr>
-
-    {% endif %}
 
   </tbody>
 </table>


### PR DESCRIPTION
Even for partially funded events, requesters should be able to edit some things:

Locked: T/F Checkmark Qs, Free Response Qs
Lock, but can Add New Items: Expenses, “Revenue” 
Unlock: Extra Funding Sources Qs, Basic Event Details, Funding Sources Checkmarks
