### PR TITLE
removed funding already received from event

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -121,8 +121,8 @@ class Event(models.Model):
     applied_funders =\
         models.ManyToManyField(CFAUser,
                                related_name='event_applied_funders')
-    funding_already_received = models.DecimalField(max_digits=17,
-                                                   decimal_places=2)
+    funding_already_received = \
+        models.DecimalField(max_digits=17, decimal_places=2, default=0)
     status = models.CharField(max_length=1, choices=STATUS)
     created_at = models.DateTimeField(default=datetime.datetime.now)
     updated_at = models.DateTimeField(default=datetime.datetime.now)

--- a/app/views.py
+++ b/app/views.py
@@ -131,7 +131,6 @@ def event_new(request):
             anticipated_attendance=request.POST['anticipatedattendance'],
             advisor_email=request.POST['advisoremail'],
             advisor_phone=request.POST['advisorphone'],
-            funding_already_received=request.POST['fundingalreadyreceived'],
         )
         event.save_from_form(request.POST)
         event.notify_funders(new=True)
@@ -177,7 +176,6 @@ def event_edit(request, event_id):
         event.anticipated_attendance = request.POST['anticipatedattendance']
         event.advisor_email = request.POST['advisoremail']
         event.advisor_phone = request.POST['advisorphone']
-        event.funding_already_received = request.POST['fundingalreadyreceived']
         event.save()
         event.save_from_form(request.POST)
         event.notify_funders(new=False)

--- a/templates/app/templatetags/event-details-form.html
+++ b/templates/app/templatetags/event-details-form.html
@@ -90,16 +90,6 @@
           <p class="help-block">Organization(s) involved with the event</p>
         </div>
       </div>
-      <div class="control-group">
-        <label for="fundingalreadyreceived" class="control-label">Funding Already Receieved</label>
-        <div class="controls">
-          <div class="input-prepend">
-              <span class="add-on">$</span>
-              <input value="{{ event.funding_already_received }}" type="number" min="0" name='fundingalreadyreceived' id="fundingalreadyreceived" class="input-xlarge" {{extra_attrs}} {{event_over_disable}}>
-          </div>
-          <p class="help-block">Amount of funding already received that has not been allocated for any particular item</p>
-        </div>
-      </div>
     </fieldset>
   </div>
 </section>

--- a/templates/app/templatetags/event-details-show.html
+++ b/templates/app/templatetags/event-details-show.html
@@ -77,15 +77,6 @@
             <input value="{{ event.advisor_phone }}" type="text" name="advisorphone" id="questionadvisorphone" class="input-xlarge" {{extra_attrs}} {{event_over_disable}}>
           </div>
         </div>
-        <div class="control-group">
-          <label for="fundingalreadyreceived" class="control-label">Funding Already Receieved</label>
-          <div class="controls">
-            <div class="input-prepend">
-              <span class="add-on">$</span>
-              <input value="{{ event.funding_already_received }}" type="number" min="0" name='fundingalreadyreceived' id="fundingalreadyreceived" class="input-xlarge" {{extra_attrs}} {{event_over_disable}}>
-            </div>
-          </div>
-        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Removed funding already received from event details since “Revenue” has been changed to “Additional Funds,” which is a concept that encompasses already received funding.
