### PR TITLE
removed a slash

### DIFF
--- a/templates/registration/activation_email.txt
+++ b/templates/registration/activation_email.txt
@@ -1,5 +1,5 @@
 Thanks for creating an account at {{site.name}}!
 
-Just go to and {{site}}/accounts/activate/{{activation_key}}/ to activate your account.
+Just go to and {{site}}accounts/activate/{{activation_key}}/ to activate your account.
 
 The key will expire in {{expiration_days}} days.


### PR DESCRIPTION
Not that it's currently broken. The link that is sent has two backslashes. The browser is capable of correctly rendering, but I'd rather not have two backslashes. If there is a reason for this behavior let me know.
