### PR TITLE
changed events show page to display a unique event name

### DIFF
--- a/templates/app/templatetags/event-details-show.html
+++ b/templates/app/templatetags/event-details-show.html
@@ -2,7 +2,7 @@
   <div class="section-header">
     <a class='section-toggle'></a>
     <h2>
-      Event
+      {{event.name}}
     <small>details about the event</small>
     </h2>
     <h4><small>Date submitted: {{ event.created_at }}</small></h4>


### PR DESCRIPTION
<img width="1054" alt="screen shot 2015-11-06 at 5 09 31 pm" src="https://cloud.githubusercontent.com/assets/8496467/11009958/67eea5e4-84a9-11e5-8cf5-d352deb0e017.png">

This is the after image of the page. It used to just say "EVENTS details about the event" but now it has a unique name. 
#246 