### PR TITLE
Remove dependency on django-templatetag-sugar

### DIFF
--- a/app/templatetags/helpers.py
+++ b/app/templatetags/helpers.py
@@ -1,16 +1,15 @@
 from app.models import Grant
 
 
-def funders_grant_data_to_item(context, item, funder_id):
+def funders_grant_data_to_item(item, funder_id):
     grant = Grant.objects.filter(item=item, funder__id=funder_id)
     return (grant[0].amount, item.id) if grant else (None, item.id)
 
 
-def funder_item_data(context, item, funders):
+def funder_item_data(item, funders):
     funders_data = []
     for funder in funders:
-        grant_amount, grant_id = funders_grant_data_to_item(context, item,
-                                                            funder.id)
+        grant_amount, grant_id = funders_grant_data_to_item(item, funder.id)
         funders_data.append((funder.id, grant_amount, grant_id))
     return (item, funders_data)
 

--- a/app/templatetags/widgets.py
+++ b/app/templatetags/widgets.py
@@ -5,17 +5,14 @@ from collections import namedtuple
 from django import template
 from django.template.loader import render_to_string
 
-from templatetag_sugar.parser import Variable, Optional
-from templatetag_sugar.register import tag
-
-
 register = template.Library()
+
 # question-answer pair
 QA = namedtuple('QA', 'question answer')
 
 
-@tag(register, [Variable(), Variable(), Variable()])
-def itemlist_requester(context, is_revenue, items, funded):
+@register.simple_tag
+def itemlist_requester(is_revenue, items, funded):
   """ Render the table of items in the requester view """
   new_context = {'funded': funded,
                  'CATEGORIES': CATEGORIES, 'is_revenue': is_revenue}
@@ -25,8 +22,8 @@ def itemlist_requester(context, is_revenue, items, funded):
                           context=new_context)
 
 
-@tag(register, [Variable(), Variable(), Variable(), Variable()])
-def itemlist_funder(context, is_revenue, items, applied_funders, funder_id):
+@register.simple_tag
+def itemlist_funder(is_revenue, items, applied_funders, funder_id):
   """ Render the table of items in the funder view """
   items_data = []
   title_row = \
@@ -41,9 +38,9 @@ def itemlist_funder(context, is_revenue, items, applied_funders, funder_id):
     if item.revenue == bool(is_revenue):
       if item.revenue:
         # applied_funders = []
-        items_data.append(funder_item_data(context, item, []))
+        items_data.append(funder_item_data(item, []))
       else:
-        items_data.append(funder_item_data(context, item, applied_funders))
+        items_data.append(funder_item_data(item, applied_funders))
   new_context = {'is_revenue': is_revenue,
                  'titles': title_row,
                  'current_funder': funder_id,
@@ -51,8 +48,8 @@ def itemlist_funder(context, is_revenue, items, applied_funders, funder_id):
   return render_to_string('app/templatetags/itemlist-funder.html', context=new_context)
 
 
-@tag(register, [Variable(), Optional([Variable()])])
-def application(context, user, event):
+@register.simple_tag
+def application(user, event):
   event = event or None
 
   new_context = {
@@ -103,7 +100,7 @@ def application(context, user, event):
 
   return render_to_string('app/templatetags/application.html', context=new_context)
 
-@tag(register, [])
+@register.simple_tag(takes_context=True)
 def event_details(context):
   if 'readonly' in context:
     return render_to_string('app/templatetags/event-details-show.html', context)

--- a/app/tests.py
+++ b/app/tests.py
@@ -252,16 +252,16 @@ class TestHelpers(TestCase):
         self.item.grant_set.all().delete()
         self.item.save()
         item_tuple = helpers.funders_grant_data_to_item(
-            None, self.item, self.funder.id)
+            self.item, self.funder.id)
         self.assertEqual((None, self.item.id), item_tuple)
 
     def test_funders_grant_data_to_item(self):
         item_tuple = helpers.funders_grant_data_to_item(
-            None, self.item, self.funder.id)
+            self.item, self.funder.id)
         self.assertEqual((50, self.item.id), item_tuple)
 
     def test_funder_item_data(self):
-        result = helpers.funder_item_data(None, self.item, [self.funder])
+        result = helpers.funder_item_data(self.item, [self.funder])
         # funder data - funder id, amount = 50, grant id = 1
         expected = (self.item, [(self.funder.id, 50, 1)])
         self.assertEqual(expected, result)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 Django==1.8.15
 dj-database-url==0.4.2
 django-registration==2.0
-django-templatetag-sugar==1.0
 django-localflavor==1.2
 gunicorn==19.7.0
 mysqlclient==1.3.10


### PR DESCRIPTION
Django-templatetag-sugar is a blocker from upgrading Django further and upgrading to Python 3. In addition, it does not seem to offer any benefit over Django's standard custom template tags in Django >1.8.