### PR TITLE
Django deprecations and Python 3+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,7 @@ sudo: false
 language: python
 python:
   - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
 script: python manage.py test -v2 app

--- a/app/models.py
+++ b/app/models.py
@@ -9,6 +9,7 @@ from django.db import models
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.template.loader import render_to_string
+from django.urls import reverse
 
 from settings import DEFAULT_FROM_EMAIL
 from settings import DEBUG
@@ -299,10 +300,9 @@ class Event(models.Model):
         identifier = "".join(id_data).encode("utf-8")
         return sha1(identifier).hexdigest()
 
-    @models.permalink
     def get_absolute_url(self):
         if self.id:
-            return ('event-show', [str(self.id)])
+            return reverse('event-show', args=[str(self.id)])
 
     def __unicode__(self):
         return "%s: %s, %s" % (unicode(self.requester),

--- a/app/models.py
+++ b/app/models.py
@@ -291,10 +291,13 @@ class Event(models.Model):
 
     @property
     def secret_key(self):
-        """Unique key that can be shared so that anyone can view the event."""
-        """To use the key append ?key=<key>"""
-        return sha1("".join([self.name, str(self.date), str(self.requester)])
-                    .encode("utf-8")).hexdigest()
+        """
+        Unique key that can be shared so that anyone can view the event.
+        To use the key append ?key=<key>
+        """
+        id_data = [self.name, str(self.date), str(self.requester.user)]
+        identifier = "".join(id_data).encode("utf-8")
+        return sha1(identifier).hexdigest()
 
     @models.permalink
     def get_absolute_url(self):

--- a/app/templatetags/widgets.py
+++ b/app/templatetags/widgets.py
@@ -91,7 +91,7 @@ def application(user, event):
 
   try:
     is_funder = user.profile.is_funder
-    if not user or not user.is_authenticated() or user.is_staff or is_funder or event.over:
+    if not user or not user.is_authenticated or user.is_staff or is_funder or event.over:
       new_context['extra_attrs'] = 'readonly'
       new_context['readonly'] = True
   except:

--- a/app/tests.py
+++ b/app/tests.py
@@ -95,6 +95,15 @@ class TestEvents(TestCase):
         resp = self.client.get('/1/')
         self.assertEqual(resp.status_code, 404)
 
+    def test_create_event(self):
+        resp = self.client.get('/new/')
+        with open('app/fixtures/event_edit.json', 'r') as f:
+            resp = self.client.post('/new/', json.load(f))
+        self.assertEqual(resp.status_code, 302)
+        resp = self.client.get('/2/')
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, 'First Round')
+
     def test_edit_event(self):
         resp = self.client.get('/1/edit/')
         self.assertEqual(resp.status_code, 200)

--- a/app/tests.py
+++ b/app/tests.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
 import json
 
 from django.test import TestCase
@@ -103,6 +106,17 @@ class TestEvents(TestCase):
         resp = self.client.get('/2/')
         self.assertEqual(resp.status_code, 200)
         self.assertContains(resp, 'First Round')
+
+    def test_create_event_utf8(self):
+        unicode_string = 'Téßt؟'
+        with open('app/fixtures/event_edit.json', 'r') as f:
+            data = json.load(f)
+            data["name"] = unicode_string
+            resp = self.client.post('/new/', data)
+        self.assertEqual(resp.status_code, 302)
+        resp = self.client.get('/2/')
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, unicode_string)
 
     def test_edit_event(self):
         resp = self.client.get('/1/edit/')

--- a/app/views.py
+++ b/app/views.py
@@ -90,8 +90,7 @@ def save_from_form(event, POST):
             # Remove unwanted commas for int parsing
             rev = rev.replace(",", "")
 
-            name = name.encode('utf-8')
-            if str(name):
+            if name:
                 event.item_set.create(name=name,
                                       quantity=quantity,
                                       price_per_unit=price,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 contextlib2==0.5.5
+Django==1.11.8
 dj-database-url==0.4.2
-Django==1.11.2
-django-localflavor==1.2
 django-registration==2.2
+django-localflavor==1.3
 gunicorn==19.7.0
-mysqlclient==1.3.10
+mysqlclient==1.3.12
 pytz==2017.3
 raven==6.5.0
-whitenoise==3.3.0
+whitenoise==3.3.1

--- a/settings.py
+++ b/settings.py
@@ -135,7 +135,7 @@ TEMPLATES = [
     },
 ]
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py27,py3
+skipsdist = True
+
+[testenv]
+deps = -rrequirements.txt
+commands = python manage.py test app


### PR DESCRIPTION
Upgrade to latest Django before 2.0 and finalize Python 3.0 compatibility. This should be released and deployed as a Python 3 app to test stability before moving forward with Django 2.0.